### PR TITLE
Adding more latency metrics

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -47,6 +47,8 @@ linters-settings:
     # Default is to use a neutral variety of English.
     # Setting locale to US will correct the British spelling of 'colour' to 'color'.
     locale: US
+    ignore-words:
+      - filterd
   lll:
     # max line length, lines longer will be reported. Default is 120.
     # '\t' is counted as 1 character by default, and can be changed with the tab-width option

--- a/pkg/decorators/rt_mock_test.go
+++ b/pkg/decorators/rt_mock_test.go
@@ -4,8 +4,9 @@
 package decorators
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	http "net/http"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of RoundTripper interface

--- a/pkg/handlers/v1/filter.go
+++ b/pkg/handlers/v1/filter.go
@@ -30,10 +30,10 @@ type configNotification struct {
 	UnsubscribeURL     string `json:"UnsubscribeURL"`
 }
 
-// ConfigEvent represents a single AWS Config Configuration Item.
+// ConfigEvent represents a single AWS Config configuration Item.
 type ConfigEvent struct {
-	ConfigurationItem domain.ConfigurationItem `json:"configurationItem"`
-	MessageType       string                   `json:"messageType"`
+	ConfigurationItem     domain.ConfigurationItem     `json:"configurationItem"`
+	MessageType           string                       `json:"messageType"`
 }
 
 // ConfigFilter applies a filter to AWS Config events.
@@ -46,13 +46,13 @@ type ConfigFilter struct {
 
 // Handle accepts Config events, applies a filter, and returns the events that match.
 func (h *ConfigFilter) Handle(ctx context.Context, in domain.SNSInput) error {
+	receivedTs := time.Now()
 	logger := h.LogFn(ctx)
 	stater := h.StatFn(ctx)
 	var event ConfigEvent
 	var notification configNotification
 	var t interface{}
 	var ok bool
-
 	if t, ok = in["Type"]; !ok {
 		return nil
 	}
@@ -73,6 +73,8 @@ func (h *ConfigFilter) Handle(ctx context.Context, in domain.SNSInput) error {
 
 	if e := json.Unmarshal([]byte(notification.Message), &event); e != nil {
 		logger.Error(logs.InvalidInput{Reason: e.Error()})
+		// Time taken for filter decision to be made within filterd
+		stater.Timing("event.awsconfig.filter.process.latency", time.Since(receivedTs))
 		return e
 	}
 
@@ -83,6 +85,8 @@ func (h *ConfigFilter) Handle(ctx context.Context, in domain.SNSInput) error {
 	if event.ConfigurationItem.ResourceType == "" {
 		e := domain.ErrInvalidInput{Reason: "empty resource type"}
 		logger.Error(logs.InvalidInput{Reason: e.Error()})
+		// Time taken for filter decision to be made within filterd
+		stater.Timing("event.awsconfig.filter.process.latency", time.Since(receivedTs))
 		return e
 	}
 	stater.Count(
@@ -93,13 +97,18 @@ func (h *ConfigFilter) Handle(ctx context.Context, in domain.SNSInput) error {
 
 	if ok := h.ConfigFilterer.FilterConfig(event.ConfigurationItem); !ok {
 		stater.Count("event.awsconfig.filter.discarded", 1)
+		// Time taken for filter decision to be made within filterd
+		stater.Timing("event.awsconfig.filter.process.latency", time.Since(receivedTs))
 		return nil
 	}
 
+	// Delay since message was put on SQS
 	if ts, err := time.Parse(time.RFC3339Nano, notification.Timestamp); err == nil {
 		stater.Timing("event.awsconfig.filter.event.delay", time.Since(ts))
 	}
 	stater.Count("event.awsconfig.filter.accepted", 1)
+	// Time taken for filter decision to be made within filterd
+	stater.Timing("event.awsconfig.filter.process.latency", time.Since(receivedTs))
 	notification.ProcessedTimestamp = time.Now().Format(time.RFC3339Nano)
 	_, err := h.Producer.Produce(ctx, notification)
 	return err

--- a/pkg/handlers/v1/filter.go
+++ b/pkg/handlers/v1/filter.go
@@ -32,8 +32,8 @@ type configNotification struct {
 
 // ConfigEvent represents a single AWS Config configuration Item.
 type ConfigEvent struct {
-	ConfigurationItem     domain.ConfigurationItem     `json:"configurationItem"`
-	MessageType           string                       `json:"messageType"`
+	ConfigurationItem domain.ConfigurationItem `json:"configurationItem"`
+	MessageType       string                   `json:"messageType"`
 }
 
 // ConfigFilter applies a filter to AWS Config events.

--- a/pkg/handlers/v1/mock_configfilterer_test.go
+++ b/pkg/handlers/v1/mock_configfilterer_test.go
@@ -5,9 +5,10 @@
 package v1
 
 import (
+	reflect "reflect"
+
 	domain "github.com/asecurityteam/awsconfig-filterd/pkg/domain"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
 )
 
 // MockConfigFilterer is a mock of ConfigFilterer interface

--- a/pkg/handlers/v1/mock_producer_test.go
+++ b/pkg/handlers/v1/mock_producer_test.go
@@ -6,8 +6,9 @@ package v1
 
 import (
 	context "context"
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockProducer is a mock of Producer interface


### PR DESCRIPTION
The desired changes are pretty small and only meant to give us a metric showing the actual time spent within the handler vs total latency.

Ran into a lot of trouble verifying this though, I've tried a couple different approaches to having a local statsd to verify (Gryg had helpfully linked a datadog statsd container that takes datadog metrics and outputs to stdout)  that have failed. 

On `make run` I consistently get console output that makes it look like the Stater component failed to instantiate even when I try to set it to NULL. I've tried checking out the clean master branch and have the same problems, but comparing it to transformerd (which does run locally fine for me) doesn't show any major differences.

Since this is for more stats emitting and not new code I don't feel horrible about that, but I would appreciate someone confirming they can run this repo with a Stats emitter set to NULL so I can figure out what's wrong with my environment.