### PR TITLE
Upgrade Go and SDCLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: false
 go:
-  - 1.12.x
+  - 1.17.x
 services:
   - docker
 install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM asecurityteam/sdcli:v1 AS BUILDER
+FROM asecurityteam/sdcli:v1.2.3 AS BUILDER
 RUN mkdir -p /go/src/github.com/asecurityteam/awsconfig-filterd
 WORKDIR /go/src/github.com/asecurityteam/awsconfig-filterd
 COPY --chown=sdcli:sdcli . .

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TAG := $(shell git rev-parse --short HEAD)
 DIR := $(shell pwd -L)
-SDCLI=asecurityteam/sdcli:v1.1.3
+SDCLI=asecurityteam/sdcli:v1.2.3
 
 dep:
 	docker run -ti \

--- a/go.mod
+++ b/go.mod
@@ -1,22 +1,52 @@
 module github.com/asecurityteam/awsconfig-filterd
 
-go 1.15
+go 1.17
 
 require (
-	bitbucket.org/atlassian/go-asap v0.0.0-20210304212240-f9c3dc6b7f47 // indirect
 	github.com/asecurityteam/component-httpclient v0.2.0
 	github.com/asecurityteam/component-producer/v2 v2.0.1
 	github.com/asecurityteam/runhttp v0.4.0
 	github.com/asecurityteam/serverfull v0.5.1
 	github.com/asecurityteam/settings v0.4.0
+	github.com/aws/aws-sdk-go v1.38.54
+	github.com/golang/mock v1.5.0
+	github.com/stretchr/testify v1.7.0
+)
+
+require (
+	bitbucket.org/atlassian/go-asap v0.0.0-20210304212240-f9c3dc6b7f47 // indirect
+	github.com/SermoDigital/jose v0.9.2-0.20161205224733-f6df55f235c2 // indirect
+	github.com/asecurityteam/component-connstate v0.2.0 // indirect
+	github.com/asecurityteam/component-expvar v0.2.0 // indirect
+	github.com/asecurityteam/component-log v0.2.0 // indirect
+	github.com/asecurityteam/component-signals v0.2.0 // indirect
+	github.com/asecurityteam/component-stat v0.3.0 // indirect
+	github.com/asecurityteam/httpstats v0.0.0-20201215174437-106328c66daa // indirect
+	github.com/asecurityteam/logevent v1.5.0 // indirect
+	github.com/asecurityteam/transport v1.6.2 // indirect
 	github.com/asecurityteam/transportd v1.3.1 // indirect
 	github.com/aws/aws-lambda-go v1.23.0 // indirect
-	github.com/aws/aws-sdk-go v1.38.54
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fatih/structs v1.1.0 // indirect
 	github.com/getkin/kin-openapi v0.49.0 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/go-chi/chi v4.1.2+incompatible // indirect
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect
-	github.com/golang/mock v1.5.0
+	github.com/go-yaml/yaml v2.1.0+incompatible // indirect
+	github.com/google/uuid v1.2.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/stretchr/testify v1.7.0
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/pquerna/cachecontrol v0.0.0-20201205024021-ac21108117ac // indirect
+	github.com/rs/xhandler v0.0.0-20170707052532-1eb70cf1520d // indirect
+	github.com/rs/xstats v0.0.0-20170813190920-c67367528e16 // indirect
+	github.com/rs/zerolog v1.20.0 // indirect
+	github.com/spf13/cast v1.3.1 // indirect
+	github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50 // indirect
 	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 // indirect
 	golang.org/x/text v0.3.5 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )


### PR DESCRIPTION
- Upgrades Go to 1.17
- Upgrades SDCLI to [v1.2.3](https://github.com/asecurityteam/sdcli/releases/tag/v1.2.3)