### PR TITLE
WIP: adding settings to run on m1 mac

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    platform: linux/x86_64
     environment:
       - SERVERFULL_RUNTIME_HTTPSERVER_ADDRESS=:8081
       - SERVERFULL_RUNTIME_CONNSTATE_REPORTINTERVAL=5s


### PR DESCRIPTION
Currently builds but fails when the go app tries to start.

Here is the strange error that fires when the app tries to start:
```
Attaching to awsconfig-filterd-app-1, awsconfig-filterd-gateway-1
awsconfig-filterd-app-1      | panic: missing POST producer endpoint
awsconfig-filterd-app-1      | 
awsconfig-filterd-app-1      | goroutine 1 [running]:
awsconfig-filterd-app-1      | main.main()
awsconfig-filterd-app-1      | 	/go/src/github.com/asecurityteam/awsconfig-filterd/main.go:94 +0x365
awsconfig-filterd-app-1 exited with code 2
```

Here is the full build log when I run `make run`
```
make run                                ok 
docker-compose up --build --abort-on-container-exit
[+] Building 123.4s (27/27) FINISHED                                            
 => [awsconfig-filterd_app internal] load build definition from Dockerfil  0.6s
 => => transferring dockerfile: 810B                                       0.0s
 => [awsconfig-filterd_gateway internal] load build definition from gatew  1.3s
 => => transferring dockerfile: 152B                                       0.0s
 => [awsconfig-filterd_app internal] load .dockerignore                    1.7s
 => => transferring context: 2B                                            0.0s
 => [awsconfig-filterd_gateway internal] load .dockerignore                1.5s
 => => transferring context: 2B                                            0.0s
 => [awsconfig-filterd_gateway internal] load metadata for docker.io/asec  1.2s
 => [awsconfig-filterd_app internal] load metadata for docker.io/library/  2.2s
 => [awsconfig-filterd_app internal] load metadata for docker.io/asecurit  0.0s
 => [auth] asecurityteam/serverfull-gateway:pull token for registry-1.doc  0.0s
 => [auth] library/alpine:pull token for registry-1.docker.io              0.0s
 => [awsconfig-filterd_gateway internal] load build context                0.6s
 => => transferring context: 3.84kB                                        0.0s
 => CACHED [awsconfig-filterd_gateway 1/2] FROM docker.io/asecurityteam/s  0.0s
 => [awsconfig-filterd_gateway 2/2] COPY api.yaml .                        2.6s
 => [awsconfig-filterd_app internal] load build context                    3.5s
 => => transferring context: 5.57MB                                        1.3s
 => [awsconfig-filterd_app certs 1/4] FROM docker.io/library/alpine:lates  4.9s
 => => resolve docker.io/library/alpine:latest@sha256:4edbd2beb5f78b10140  0.6s
 => => sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6 1.64kB / 1.64kB  0.0s
 => => sha256:a777c9c66ba177ccfea23f2a216ff6721e78a662cd17019 528B / 528B  0.0s
 => => sha256:0ac33e5f5afa79e084075e8698a22d574816eea8d7b 1.47kB / 1.47kB  0.0s
 => => sha256:df9b9388f04ad6279a7410b85cedfdcb2208c0a003d 2.81MB / 2.81MB  1.8s
 => => extracting sha256:df9b9388f04ad6279a7410b85cedfdcb2208c0a003da7ab5  0.1s
 => [awsconfig-filterd_app builder 1/6] FROM docker.io/asecurityteam/sdc  25.1s
 => [awsconfig-filterd_app] exporting to image                             3.2s
 => => exporting layers                                                    0.9s
 => => writing image sha256:1264389b492e5c95f3014652bec1bfdbaa518f74be33d  0.1s
 => => naming to docker.io/library/awsconfig-filterd_gateway               0.1s
 => => writing image sha256:0552ede43c2a16ae4479cda647413dc9e87f3485d98d7  0.0s
 => => naming to docker.io/library/awsconfig-filterd_app                   0.0s
 => [awsconfig-filterd_app certs 2/4] RUN apk --no-cache add tzdata zip c  3.9s
 => [awsconfig-filterd_app certs 3/4] WORKDIR /usr/share/zoneinfo          2.0s
 => [awsconfig-filterd_app certs 4/4] RUN zip -r -0 /zoneinfo.zip .        2.9s
 => [awsconfig-filterd_app builder 2/6] RUN mkdir -p /go/src/github.com/a  1.3s
 => [awsconfig-filterd_app builder 3/6] WORKDIR /go/src/github.com/asecur  0.8s
 => [awsconfig-filterd_app builder 4/6] COPY --chown=sdcli:sdcli . .       0.9s
 => [awsconfig-filterd_app builder 5/6] RUN sdcli go dep                  14.7s
 => [awsconfig-filterd_app builder 6/6] RUN CGO_ENABLED=0 GOOS=linux go   72.5s
 => [awsconfig-filterd_app stage-2 1/3] COPY --from=BUILDER /opt/app .     0.6s
 => [awsconfig-filterd_app stage-2 2/3] COPY --from=CERTS /zoneinfo.zip /  0.8s
 => [awsconfig-filterd_app stage-2 3/3] COPY --from=CERTS /etc/ssl/certs/  0.8s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
[+] Running 3/3
 ⠿ Network awsconfig-filterd_default      Created                          0.3s
 ⠿ Container awsconfig-filterd-app-1      Created                          1.2s
 ⠿ Container awsconfig-filterd-gateway-1  Created                          1.2s
Attaching to awsconfig-filterd-app-1, awsconfig-filterd-gateway-1
awsconfig-filterd-app-1      | panic: missing POST producer endpoint
awsconfig-filterd-app-1      | 
awsconfig-filterd-app-1      | goroutine 1 [running]:
awsconfig-filterd-app-1      | main.main()
awsconfig-filterd-app-1      | 	/go/src/github.com/asecurityteam/awsconfig-filterd/main.go:94 +0x365
awsconfig-filterd-app-1 exited with code 2
Aborting on container exit...
[+] Running 2/2
 ⠿ Container awsconfig-filterd-app-1      Stopped                          0.0s
 ⠿ Container awsconfig-filterd-gateway-1  Stopped                          0.6s```